### PR TITLE
Manually specify callback method

### DIFF
--- a/lib/omniauth/strategies/orcid.rb
+++ b/lib/omniauth/strategies/orcid.rb
@@ -127,6 +127,10 @@ module OmniAuth
           urls: {}
         }
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/omniauth-orcid.gemspec
+++ b/omniauth-orcid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Declary dependencies here, rather than in the Gemfile
-  s.add_dependency 'omniauth-oauth2', '~> 1.3.1'
+  s.add_dependency 'omniauth-oauth2', '~> 1.3'
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rack-test', '~> 0.6.3'


### PR DESCRIPTION
omniauth-oauth2 v. 1.4 [stops automatically providing callback_url](https://github.com/intridea/omniauth-oauth2/pull/70) method.
This adds the method to the orcid strategy so the gem can be used with omniauth-oauth 1.4