### PR TITLE
Update token_url to current ORCID spec

### DIFF
--- a/lib/omniauth/strategies/orcid.rb
+++ b/lib/omniauth/strategies/orcid.rb
@@ -82,16 +82,20 @@ module OmniAuth
         end
       end
 
-      def authorize_url
+      def root_url
         if options[:sandbox]
-          'https://sandbox.orcid.org/oauth/authorize'
+          'https://sandbox.orcid.org'
         else
-          'https://orcid.org/oauth/authorize'
+          'https://orcid.org'
         end
       end
 
+      def authorize_url
+        root_url + '/oauth/authorize'
+      end
+
       def token_url
-        site + '/oauth/token'
+        root_url + '/oauth/token'
       end
 
       def scope

--- a/spec/omniauth/strategies/orcid_spec.rb
+++ b/spec/omniauth/strategies/orcid_spec.rb
@@ -39,7 +39,7 @@ describe OmniAuth::Strategies::ORCID do
       end
 
       it 'should have correct token url' do
-        expect(subject.options.client_options.token_url).to eq("https://pub.orcid.org/oauth/token")
+        expect(subject.options.client_options.token_url).to eq("https://orcid.org/oauth/token")
       end
 
       it 'should have correct authorize url' do
@@ -65,7 +65,7 @@ describe OmniAuth::Strategies::ORCID do
       end
 
       it 'should have correct token url' do
-        expect(subject.options.client_options.token_url).to eq("https://pub.sandbox.orcid.org/oauth/token")
+        expect(subject.options.client_options.token_url).to eq("https://sandbox.orcid.org/oauth/token")
       end
 
       it 'should have correct authorize url' do
@@ -91,7 +91,7 @@ describe OmniAuth::Strategies::ORCID do
       end
 
       it 'should have correct token url' do
-        expect(subject.options.client_options.token_url).to eq("https://api.orcid.org/oauth/token")
+        expect(subject.options.client_options.token_url).to eq("https://orcid.org/oauth/token")
       end
     end
 
@@ -109,7 +109,7 @@ describe OmniAuth::Strategies::ORCID do
       end
 
       it 'should have correct token url' do
-        expect(subject.options.client_options.token_url).to eq("https://api.sandbox.orcid.org/oauth/token")
+        expect(subject.options.client_options.token_url).to eq("https://sandbox.orcid.org/oauth/token")
       end
     end
 


### PR DESCRIPTION
Update `token_url` to use use the site root URL as [specified by ORCID](https://members.orcid.org/api/news/use-root-url-when-requesting-oauth-tokens).

- Update `token_url`
- Refactor common parts of `token_url` and `authorize_url`