### PR TITLE
ORCID honours the state param, so no need to ignore it

### DIFF
--- a/lib/omniauth/strategies/orcid.rb
+++ b/lib/omniauth/strategies/orcid.rb
@@ -12,7 +12,7 @@ module OmniAuth
 
       option :member, false
       option :sandbox, false
-      option :provider_ignores_state, true
+      option :provider_ignores_state, false
 
       option :authorize_options, [:redirect_uri,
                                   :show_login,


### PR DESCRIPTION
The current [ORCID docs](https://members.orcid.org/api/integrate/orcid-sign-in) say:

> Appended to the end of that link will be a six-digit authorization code and any state parameter you specified

We've tested this in our system (a rails app at theconversation.com) and confirmed that sign in via ORCID continues to work when `provider_ignores_state` is set to `false`.

oauth2 sign ins are reportedly safer when the state param is checked, so it may be worth changing the default behaviour.