### PR TITLE
Remove redundant script_name from callback_url

### DIFF
--- a/lib/omniauth/strategies/orcid.rb
+++ b/lib/omniauth/strategies/orcid.rb
@@ -151,7 +151,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        full_host + callback_path
       end
     end
   end


### PR DESCRIPTION
OmniAuth::Strategy#callback_path now includes script_name, so concatenating it in #callback_url causes it to be doubled.

This was changed upstream in
https://github.com/omniauth/omniauth/commit/c606a00798a7f516c37c67a708864f9a3eb9f796.

Fixes #18.